### PR TITLE
Set up pathmap to hide local folder structure

### DIFF
--- a/CelesteMod/CelesteMod.csproj
+++ b/CelesteMod/CelesteMod.csproj
@@ -59,5 +59,9 @@
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
     </Target>
+    
+    <PropertyGroup>
+        <PathMap>$(MSBuildProjectDirectory)=CelesteMod/</PathMap>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This prevents people from accidentally doxxing themselves via stacktraces if shipping the .pdb.