### PR TITLE
Fix architecture warning

### DIFF
--- a/CelesteMod/CelesteMod.csproj
+++ b/CelesteMod/CelesteMod.csproj
@@ -63,5 +63,9 @@
     <PropertyGroup>
         <PathMap>$(MSBuildProjectDirectory)=CelesteMod/</PathMap>
     </PropertyGroup>
+    
+    <PropertyGroup>
+        <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This disables the warning "There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference", which otherwise usually appears at least once when building a mod and can be safely ignored.