### PR TITLE
Remove unused step and fix env var in workflow

### DIFF
--- a/CelesteMod/.github/workflows/dotnet-core.yml
+++ b/CelesteMod/.github/workflows/dotnet-core.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Parse Everest Dependency
-      run: echo "EVERESTDEP=$(yq eval '.[0].Dependencies[] | select(.Name == "Everest").Version' -- everest.yaml)"
-
     - name: Download Everest stripped lib
       uses: robinraju/release-downloader@v1.4
       with:
@@ -33,7 +30,7 @@ jobs:
     - name: Build
       run: dotnet build CelesteMod.csproj --configuration Release --no-restore
       env:
-        CELESTEPREFIX: ${{ github.workspace }}/lib-stripped
+        CelestePrefix: ${{ github.workspace }}/lib-stripped
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
- follow-up to #4

Workflow will always build against latest stable
