### PR TITLE
Include program database on build

### DIFF
--- a/CelesteMod/CelesteMod.csproj
+++ b/CelesteMod/CelesteMod.csproj
@@ -58,6 +58,7 @@
 
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
+		<Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
     </Target>
     
     <PropertyGroup>

--- a/CelesteMod/CelesteMod.csproj
+++ b/CelesteMod/CelesteMod.csproj
@@ -58,7 +58,7 @@
 
     <Target Name="CopyFiles" AfterTargets="Build">
         <Copy SourceFiles="$(OutputPath)\$(AssemblyName).dll" DestinationFolder="bin" />
-		<Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
+        <Copy SourceFiles="$(OutputPath)\$(AssemblyName).pdb" DestinationFolder="bin" />
     </Target>
     
     <PropertyGroup>


### PR DESCRIPTION
This PR makes the template include the `.pdb` file on build, which makes stacktraces include the file and line number.
See conversation here: https://discord.com/channels/403698615446536203/429775320720211968/1121616699884580885